### PR TITLE
Add setup.py to allow installation as a Python package

### DIFF
--- a/PyMCTranslate/__init__.py
+++ b/PyMCTranslate/__init__.py
@@ -3,7 +3,7 @@ from PyMCTranslate.py3.translation_manager import TranslationManager
 
 
 def new_translation_manager() -> TranslationManager:
-	"""Returns a new TranslationManager with the default files.
-	Each unique world should have a new TranslationManager because there is the
-	functionality to register custom (mod) blocks making each handler unique."""
-	return TranslationManager(os.path.join(os.path.dirname(__file__), 'json'))
+    """Returns a new TranslationManager with the default files.
+    Each unique world should have a new TranslationManager because there is the
+    functionality to register custom (mod) blocks making each handler unique."""
+    return TranslationManager(os.path.join(os.path.dirname(__file__), 'json'))

--- a/PyMCTranslate/py3/__init__.py
+++ b/PyMCTranslate/py3/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import annotations

--- a/PyMCTranslate/py3/helpers/__init__.py
+++ b/PyMCTranslate/py3/helpers/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import annotations

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,52 @@
+import sys
+import os
+from setuptools import setup, Extension, find_packages
+
+CYTHON_COMPILE = False
+try:
+    from Cython.Build import cythonize
+
+    CYTHON_COMPILE = True
+except Exception:
+    pass
+
+requirements_fp = open(os.path.join(".", "requirements.txt"))
+requirements = [line for line in requirements_fp.readlines() if not line.startswith('git+')]
+requirements_fp.close()
+
+packages = find_packages(
+    include=[
+        "*",
+        "PyMCTranslate.*",
+        "PyMCTranslate.py3.*",
+        "PyMCTranslate.py3.api.*",
+        "PyMCTranslate.py3.helpers.*",
+        "PyMCTranslate.json.*",
+    ],
+    exclude=["PyMCTranslate.py2.*"],
+)
+
+extensions = [
+    Extension(
+        name="PyMCTranslate.py3.translate", sources=["PyMCTranslate/py3/translate.pyx"]
+    )
+]
+
+SETUP_PARAMS = {
+    "name": "pymctranslate",
+    "install_requires": requirements,
+    "packages": packages,
+    "include_package_data": True,
+    "zip_safe": False,
+    "package_data": {
+        "PyMCTranslate": [
+            "json/versions/*/*/*/*/*/*/*.json",
+            "json/versions/*/*.json"
+        ]
+    },
+}
+
+if CYTHON_COMPILE and os.path.exists(os.path.join('.', extensions[0].sources[0])):
+    SETUP_PARAMS["ext_modules"] = cythonize(extensions, language_level=3, annotate=True)
+
+setup(**SETUP_PARAMS)

--- a/tests/basic_test.py
+++ b/tests/basic_test.py
@@ -1,14 +1,14 @@
 import PyMCTranslate
-from PyMCTranslate.py3.api.block import Block
+from amulet.api.block import Block
 translations = PyMCTranslate.new_translation_manager()
 
 print('==== bedrock_1_7_0 ====')
 for data in range(16):
 	print(
-		translations.get_sub_version('bedrock', (1, 7, 0)).to_universal(None, Block(None, 'minecraft', 'log', {'block_data': str(data)}))[0]
+		translations.get_sub_version('bedrock', (1, 7, 0)).to_universal(Block(None, 'minecraft', 'log', {'block_data': str(data)}))[0]
 	)
 print('==== java_1_12_2 ====')
 for data in range(16):
 	print(
-		translations.get_sub_version('java', (1, 12, 2)).to_universal(None, Block(None, 'minecraft', 'log', {'block_data': str(data)}))[0]
+		translations.get_sub_version('java', (1, 12, 2)).to_universal(Block(None, 'minecraft', 'log', {'block_data': str(data)}))[0]
 	)


### PR DESCRIPTION
### Changes

- Added a `setup.py` to allow for the translation library to be installed as a Python module
    - Include preparation setup/compilation code for a cython version for sometime in the future
    - Includes all `.json` data files needed for translations
- Added empty `__init__.py` files to properly detect packages and sub-packages
- Fixed API calls in `basic_test.py` to confirm that package installation works correctly