### PR TITLE
Moved data file collection to MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,5 @@
 recursive-include PyMCTranslate/json/versions/* *.*
-recursive-include PyMCTranslate/code_functions/* *.py
+include PyMCTranslate/code_functions/*.py
 include PyMCTranslate/build_number
 prune */__pycache__/*
 global-exclude *.py[cod]

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,5 @@
+recursive-include PyMCTranslate/json/versions/* *.*
+recursive-include PyMCTranslate/code_functions/* *.py
+include PyMCTranslate/build_number
+prune */__pycache__/*
+global-exclude *.py[cod]

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,6 @@ SETUP_PARAMS = {
     "packages": packages,
     "include_package_data": True,
     "zip_safe": False,
-    "package_data": {"PyMCTranslate": package_data},
 }
 
 if CYTHON_COMPILE and os.path.exists(os.path.join(".", extensions[0].sources[0])):

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ extensions = [
 
 package_data_locations = (("json", "versions"), ("code_functions",))
 
-package_data = []
+package_data = ["build_number",]
 for location_data_tuple in package_data_locations:
     location_files = []
     for root, _, filenames in os.walk(

--- a/setup.py
+++ b/setup.py
@@ -34,20 +34,6 @@ extensions = [
     )
 ]
 
-package_data_locations = (("json", "versions"), ("code_functions",))
-
-package_data = ["build_number",]
-for location_data_tuple in package_data_locations:
-    location_files = []
-    for root, _, filenames in os.walk(
-        op.join(op.dirname(__file__), "PyMCTranslate", *location_data_tuple)
-    ):
-        for filename in filenames:
-            if "__pycache__" in root:
-                continue
-            location_files.append(op.join(root, filename))
-    package_data.extend(location_files)
-
 SETUP_PARAMS = {
     "name": "pymctranslate",
     "install_requires": requirements,


### PR DESCRIPTION
Changes:
- Data file collection has been removed from `setup.py`
- A new file named `MANIFEST.in` now handles data file collection
  - This is the preferred way to include data files according to the [python docs](https://docs.python.org/3/distutils/sourcedist.html#the-manifest-in-template)
  - Allows for easier inclusion of future data files that don't already exist in the current data file directories
- The `build_number` file is now properly included as well
  - Also fixes the issue of it being missing in our Amulet builds