### PR TITLE
Removed legacy pyinstaller code

### DIFF
--- a/.github/workflows/python-unittests.yml
+++ b/.github/workflows/python-unittests.yml
@@ -25,6 +25,6 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -e .
+        pip install .
     - name: Test with unittest
       run: python -m unittest discover -v -s tests

--- a/PyMCTranslate/py3/api/version/code_functions.py
+++ b/PyMCTranslate/py3/api/version/code_functions.py
@@ -16,18 +16,8 @@ def _load_functions():
     package = PyMCTranslate.code_functions
     package_prefix = package.__name__ + "."
 
-    # python file support
     for _, name, _ in pkgutil.walk_packages(package.__path__, package_prefix):
         _load_function(name)
-
-    # pyinstaller support
-    toc = set()
-    for importer in pkgutil.iter_importers(PyMCTranslate.__name__):
-        if hasattr(importer, "toc"):
-            toc |= importer.toc
-    for module_name in toc:
-        if module_name.startswith(package_prefix):
-            _load_function(module_name)
 
 
 _load_functions()


### PR DESCRIPTION
This code was previously required to make the code work with pyinstaller but pyinstaller fixed the issue meaning this code imported everything twice.