### PR TITLE
Fix 1.12.2 upper door mapping

### DIFF
--- a/PyMCTranslate/json/versions/java_1_12_2/block/numerical/to_universal/minecraft/vanilla/acacia_door.json
+++ b/PyMCTranslate/json/versions/java_1_12_2/block/numerical/to_universal/minecraft/vanilla/acacia_door.json
@@ -678,7 +678,7 @@
                                                                     "function": "new_properties",
                                                                     "options": {
                                                                         "open": "\"false\"",
-                                                                        "facing": "\"east\""
+                                                                        "facing": "\"south\""
                                                                     }
                                                                 }
                                                             ],
@@ -687,7 +687,7 @@
                                                                     "function": "new_properties",
                                                                     "options": {
                                                                         "open": "\"false\"",
-                                                                        "facing": "\"east\""
+                                                                        "facing": "\"west\""
                                                                     }
                                                                 }
                                                             ],
@@ -696,7 +696,7 @@
                                                                     "function": "new_properties",
                                                                     "options": {
                                                                         "open": "\"false\"",
-                                                                        "facing": "\"east\""
+                                                                        "facing": "\"north\""
                                                                     }
                                                                 }
                                                             ],
@@ -704,7 +704,7 @@
                                                                 {
                                                                     "function": "new_properties",
                                                                     "options": {
-                                                                        "open": "\"false\"",
+                                                                        "open": "\"true\"",
                                                                         "facing": "\"east\""
                                                                     }
                                                                 }
@@ -713,8 +713,8 @@
                                                                 {
                                                                     "function": "new_properties",
                                                                     "options": {
-                                                                        "open": "\"false\"",
-                                                                        "facing": "\"east\""
+                                                                        "open": "\"true\"",
+                                                                        "facing": "\"south\""
                                                                     }
                                                                 }
                                                             ],
@@ -722,8 +722,8 @@
                                                                 {
                                                                     "function": "new_properties",
                                                                     "options": {
-                                                                        "open": "\"false\"",
-                                                                        "facing": "\"east\""
+                                                                        "open": "\"true\"",
+                                                                        "facing": "\"west\""
                                                                     }
                                                                 }
                                                             ],
@@ -731,8 +731,8 @@
                                                                 {
                                                                     "function": "new_properties",
                                                                     "options": {
-                                                                        "open": "\"false\"",
-                                                                        "facing": "\"east\""
+                                                                        "open": "\"true\"",
+                                                                        "facing": "\"north\""
                                                                     }
                                                                 }
                                                             ]
@@ -783,7 +783,7 @@
                                                                     "function": "new_properties",
                                                                     "options": {
                                                                         "open": "\"false\"",
-                                                                        "facing": "\"south\""
+                                                                        "facing": "\"east\""
                                                                     }
                                                                 }
                                                             ],
@@ -801,7 +801,7 @@
                                                                     "function": "new_properties",
                                                                     "options": {
                                                                         "open": "\"false\"",
-                                                                        "facing": "\"south\""
+                                                                        "facing": "\"west\""
                                                                     }
                                                                 }
                                                             ],
@@ -810,7 +810,7 @@
                                                                     "function": "new_properties",
                                                                     "options": {
                                                                         "open": "\"false\"",
-                                                                        "facing": "\"south\""
+                                                                        "facing": "\"north\""
                                                                     }
                                                                 }
                                                             ],
@@ -818,8 +818,8 @@
                                                                 {
                                                                     "function": "new_properties",
                                                                     "options": {
-                                                                        "open": "\"false\"",
-                                                                        "facing": "\"south\""
+                                                                        "open": "\"true\"",
+                                                                        "facing": "\"east\""
                                                                     }
                                                                 }
                                                             ],
@@ -827,7 +827,7 @@
                                                                 {
                                                                     "function": "new_properties",
                                                                     "options": {
-                                                                        "open": "\"false\"",
+                                                                        "open": "\"true\"",
                                                                         "facing": "\"south\""
                                                                     }
                                                                 }
@@ -836,8 +836,8 @@
                                                                 {
                                                                     "function": "new_properties",
                                                                     "options": {
-                                                                        "open": "\"false\"",
-                                                                        "facing": "\"south\""
+                                                                        "open": "\"true\"",
+                                                                        "facing": "\"west\""
                                                                     }
                                                                 }
                                                             ],
@@ -845,8 +845,8 @@
                                                                 {
                                                                     "function": "new_properties",
                                                                     "options": {
-                                                                        "open": "\"false\"",
-                                                                        "facing": "\"south\""
+                                                                        "open": "\"true\"",
+                                                                        "facing": "\"north\""
                                                                     }
                                                                 }
                                                             ]
@@ -897,7 +897,7 @@
                                                                     "function": "new_properties",
                                                                     "options": {
                                                                         "open": "\"false\"",
-                                                                        "facing": "\"west\""
+                                                                        "facing": "\"east\""
                                                                     }
                                                                 }
                                                             ],
@@ -906,7 +906,7 @@
                                                                     "function": "new_properties",
                                                                     "options": {
                                                                         "open": "\"false\"",
-                                                                        "facing": "\"west\""
+                                                                        "facing": "\"south\""
                                                                     }
                                                                 }
                                                             ],
@@ -924,7 +924,7 @@
                                                                     "function": "new_properties",
                                                                     "options": {
                                                                         "open": "\"false\"",
-                                                                        "facing": "\"west\""
+                                                                        "facing": "\"north\""
                                                                     }
                                                                 }
                                                             ],
@@ -932,8 +932,8 @@
                                                                 {
                                                                     "function": "new_properties",
                                                                     "options": {
-                                                                        "open": "\"false\"",
-                                                                        "facing": "\"west\""
+                                                                        "open": "\"true\"",
+                                                                        "facing": "\"east\""
                                                                     }
                                                                 }
                                                             ],
@@ -941,8 +941,8 @@
                                                                 {
                                                                     "function": "new_properties",
                                                                     "options": {
-                                                                        "open": "\"false\"",
-                                                                        "facing": "\"west\""
+                                                                        "open": "\"true\"",
+                                                                        "facing": "\"south\""
                                                                     }
                                                                 }
                                                             ],
@@ -950,7 +950,7 @@
                                                                 {
                                                                     "function": "new_properties",
                                                                     "options": {
-                                                                        "open": "\"false\"",
+                                                                        "open": "\"true\"",
                                                                         "facing": "\"west\""
                                                                     }
                                                                 }
@@ -959,8 +959,8 @@
                                                                 {
                                                                     "function": "new_properties",
                                                                     "options": {
-                                                                        "open": "\"false\"",
-                                                                        "facing": "\"west\""
+                                                                        "open": "\"true\"",
+                                                                        "facing": "\"north\""
                                                                     }
                                                                 }
                                                             ]
@@ -1011,7 +1011,7 @@
                                                                     "function": "new_properties",
                                                                     "options": {
                                                                         "open": "\"false\"",
-                                                                        "facing": "\"north\""
+                                                                        "facing": "\"east\""
                                                                     }
                                                                 }
                                                             ],
@@ -1020,7 +1020,7 @@
                                                                     "function": "new_properties",
                                                                     "options": {
                                                                         "open": "\"false\"",
-                                                                        "facing": "\"north\""
+                                                                        "facing": "\"south\""
                                                                     }
                                                                 }
                                                             ],
@@ -1029,7 +1029,7 @@
                                                                     "function": "new_properties",
                                                                     "options": {
                                                                         "open": "\"false\"",
-                                                                        "facing": "\"north\""
+                                                                        "facing": "\"west\""
                                                                     }
                                                                 }
                                                             ],
@@ -1046,8 +1046,8 @@
                                                                 {
                                                                     "function": "new_properties",
                                                                     "options": {
-                                                                        "open": "\"false\"",
-                                                                        "facing": "\"north\""
+                                                                        "open": "\"true\"",
+                                                                        "facing": "\"east\""
                                                                     }
                                                                 }
                                                             ],
@@ -1055,8 +1055,8 @@
                                                                 {
                                                                     "function": "new_properties",
                                                                     "options": {
-                                                                        "open": "\"false\"",
-                                                                        "facing": "\"north\""
+                                                                        "open": "\"true\"",
+                                                                        "facing": "\"south\""
                                                                     }
                                                                 }
                                                             ],
@@ -1064,8 +1064,8 @@
                                                                 {
                                                                     "function": "new_properties",
                                                                     "options": {
-                                                                        "open": "\"false\"",
-                                                                        "facing": "\"north\""
+                                                                        "open": "\"true\"",
+                                                                        "facing": "\"west\""
                                                                     }
                                                                 }
                                                             ],
@@ -1073,7 +1073,7 @@
                                                                 {
                                                                     "function": "new_properties",
                                                                     "options": {
-                                                                        "open": "\"false\"",
+                                                                        "open": "\"true\"",
                                                                         "facing": "\"north\""
                                                                     }
                                                                 }

--- a/PyMCTranslate/json/versions/java_1_12_2/block/numerical/to_universal/minecraft/vanilla/birch_door.json
+++ b/PyMCTranslate/json/versions/java_1_12_2/block/numerical/to_universal/minecraft/vanilla/birch_door.json
@@ -678,7 +678,7 @@
                                                                     "function": "new_properties",
                                                                     "options": {
                                                                         "open": "\"false\"",
-                                                                        "facing": "\"east\""
+                                                                        "facing": "\"south\""
                                                                     }
                                                                 }
                                                             ],
@@ -687,7 +687,7 @@
                                                                     "function": "new_properties",
                                                                     "options": {
                                                                         "open": "\"false\"",
-                                                                        "facing": "\"east\""
+                                                                        "facing": "\"west\""
                                                                     }
                                                                 }
                                                             ],
@@ -696,7 +696,7 @@
                                                                     "function": "new_properties",
                                                                     "options": {
                                                                         "open": "\"false\"",
-                                                                        "facing": "\"east\""
+                                                                        "facing": "\"north\""
                                                                     }
                                                                 }
                                                             ],
@@ -704,7 +704,7 @@
                                                                 {
                                                                     "function": "new_properties",
                                                                     "options": {
-                                                                        "open": "\"false\"",
+                                                                        "open": "\"true\"",
                                                                         "facing": "\"east\""
                                                                     }
                                                                 }
@@ -713,8 +713,8 @@
                                                                 {
                                                                     "function": "new_properties",
                                                                     "options": {
-                                                                        "open": "\"false\"",
-                                                                        "facing": "\"east\""
+                                                                        "open": "\"true\"",
+                                                                        "facing": "\"south\""
                                                                     }
                                                                 }
                                                             ],
@@ -722,8 +722,8 @@
                                                                 {
                                                                     "function": "new_properties",
                                                                     "options": {
-                                                                        "open": "\"false\"",
-                                                                        "facing": "\"east\""
+                                                                        "open": "\"true\"",
+                                                                        "facing": "\"west\""
                                                                     }
                                                                 }
                                                             ],
@@ -731,8 +731,8 @@
                                                                 {
                                                                     "function": "new_properties",
                                                                     "options": {
-                                                                        "open": "\"false\"",
-                                                                        "facing": "\"east\""
+                                                                        "open": "\"true\"",
+                                                                        "facing": "\"north\""
                                                                     }
                                                                 }
                                                             ]
@@ -783,7 +783,7 @@
                                                                     "function": "new_properties",
                                                                     "options": {
                                                                         "open": "\"false\"",
-                                                                        "facing": "\"south\""
+                                                                        "facing": "\"east\""
                                                                     }
                                                                 }
                                                             ],
@@ -801,7 +801,7 @@
                                                                     "function": "new_properties",
                                                                     "options": {
                                                                         "open": "\"false\"",
-                                                                        "facing": "\"south\""
+                                                                        "facing": "\"west\""
                                                                     }
                                                                 }
                                                             ],
@@ -810,7 +810,7 @@
                                                                     "function": "new_properties",
                                                                     "options": {
                                                                         "open": "\"false\"",
-                                                                        "facing": "\"south\""
+                                                                        "facing": "\"north\""
                                                                     }
                                                                 }
                                                             ],
@@ -818,8 +818,8 @@
                                                                 {
                                                                     "function": "new_properties",
                                                                     "options": {
-                                                                        "open": "\"false\"",
-                                                                        "facing": "\"south\""
+                                                                        "open": "\"true\"",
+                                                                        "facing": "\"east\""
                                                                     }
                                                                 }
                                                             ],
@@ -827,7 +827,7 @@
                                                                 {
                                                                     "function": "new_properties",
                                                                     "options": {
-                                                                        "open": "\"false\"",
+                                                                        "open": "\"true\"",
                                                                         "facing": "\"south\""
                                                                     }
                                                                 }
@@ -836,8 +836,8 @@
                                                                 {
                                                                     "function": "new_properties",
                                                                     "options": {
-                                                                        "open": "\"false\"",
-                                                                        "facing": "\"south\""
+                                                                        "open": "\"true\"",
+                                                                        "facing": "\"west\""
                                                                     }
                                                                 }
                                                             ],
@@ -845,8 +845,8 @@
                                                                 {
                                                                     "function": "new_properties",
                                                                     "options": {
-                                                                        "open": "\"false\"",
-                                                                        "facing": "\"south\""
+                                                                        "open": "\"true\"",
+                                                                        "facing": "\"north\""
                                                                     }
                                                                 }
                                                             ]
@@ -897,7 +897,7 @@
                                                                     "function": "new_properties",
                                                                     "options": {
                                                                         "open": "\"false\"",
-                                                                        "facing": "\"west\""
+                                                                        "facing": "\"east\""
                                                                     }
                                                                 }
                                                             ],
@@ -906,7 +906,7 @@
                                                                     "function": "new_properties",
                                                                     "options": {
                                                                         "open": "\"false\"",
-                                                                        "facing": "\"west\""
+                                                                        "facing": "\"south\""
                                                                     }
                                                                 }
                                                             ],
@@ -924,7 +924,7 @@
                                                                     "function": "new_properties",
                                                                     "options": {
                                                                         "open": "\"false\"",
-                                                                        "facing": "\"west\""
+                                                                        "facing": "\"north\""
                                                                     }
                                                                 }
                                                             ],
@@ -932,8 +932,8 @@
                                                                 {
                                                                     "function": "new_properties",
                                                                     "options": {
-                                                                        "open": "\"false\"",
-                                                                        "facing": "\"west\""
+                                                                        "open": "\"true\"",
+                                                                        "facing": "\"east\""
                                                                     }
                                                                 }
                                                             ],
@@ -941,8 +941,8 @@
                                                                 {
                                                                     "function": "new_properties",
                                                                     "options": {
-                                                                        "open": "\"false\"",
-                                                                        "facing": "\"west\""
+                                                                        "open": "\"true\"",
+                                                                        "facing": "\"south\""
                                                                     }
                                                                 }
                                                             ],
@@ -950,7 +950,7 @@
                                                                 {
                                                                     "function": "new_properties",
                                                                     "options": {
-                                                                        "open": "\"false\"",
+                                                                        "open": "\"true\"",
                                                                         "facing": "\"west\""
                                                                     }
                                                                 }
@@ -959,8 +959,8 @@
                                                                 {
                                                                     "function": "new_properties",
                                                                     "options": {
-                                                                        "open": "\"false\"",
-                                                                        "facing": "\"west\""
+                                                                        "open": "\"true\"",
+                                                                        "facing": "\"north\""
                                                                     }
                                                                 }
                                                             ]
@@ -1011,7 +1011,7 @@
                                                                     "function": "new_properties",
                                                                     "options": {
                                                                         "open": "\"false\"",
-                                                                        "facing": "\"north\""
+                                                                        "facing": "\"east\""
                                                                     }
                                                                 }
                                                             ],
@@ -1020,7 +1020,7 @@
                                                                     "function": "new_properties",
                                                                     "options": {
                                                                         "open": "\"false\"",
-                                                                        "facing": "\"north\""
+                                                                        "facing": "\"south\""
                                                                     }
                                                                 }
                                                             ],
@@ -1029,7 +1029,7 @@
                                                                     "function": "new_properties",
                                                                     "options": {
                                                                         "open": "\"false\"",
-                                                                        "facing": "\"north\""
+                                                                        "facing": "\"west\""
                                                                     }
                                                                 }
                                                             ],
@@ -1046,8 +1046,8 @@
                                                                 {
                                                                     "function": "new_properties",
                                                                     "options": {
-                                                                        "open": "\"false\"",
-                                                                        "facing": "\"north\""
+                                                                        "open": "\"true\"",
+                                                                        "facing": "\"east\""
                                                                     }
                                                                 }
                                                             ],
@@ -1055,8 +1055,8 @@
                                                                 {
                                                                     "function": "new_properties",
                                                                     "options": {
-                                                                        "open": "\"false\"",
-                                                                        "facing": "\"north\""
+                                                                        "open": "\"true\"",
+                                                                        "facing": "\"south\""
                                                                     }
                                                                 }
                                                             ],
@@ -1064,8 +1064,8 @@
                                                                 {
                                                                     "function": "new_properties",
                                                                     "options": {
-                                                                        "open": "\"false\"",
-                                                                        "facing": "\"north\""
+                                                                        "open": "\"true\"",
+                                                                        "facing": "\"west\""
                                                                     }
                                                                 }
                                                             ],
@@ -1073,7 +1073,7 @@
                                                                 {
                                                                     "function": "new_properties",
                                                                     "options": {
-                                                                        "open": "\"false\"",
+                                                                        "open": "\"true\"",
                                                                         "facing": "\"north\""
                                                                     }
                                                                 }

--- a/PyMCTranslate/json/versions/java_1_12_2/block/numerical/to_universal/minecraft/vanilla/dark_oak_door.json
+++ b/PyMCTranslate/json/versions/java_1_12_2/block/numerical/to_universal/minecraft/vanilla/dark_oak_door.json
@@ -678,7 +678,7 @@
                                                                     "function": "new_properties",
                                                                     "options": {
                                                                         "open": "\"false\"",
-                                                                        "facing": "\"east\""
+                                                                        "facing": "\"south\""
                                                                     }
                                                                 }
                                                             ],
@@ -687,7 +687,7 @@
                                                                     "function": "new_properties",
                                                                     "options": {
                                                                         "open": "\"false\"",
-                                                                        "facing": "\"east\""
+                                                                        "facing": "\"west\""
                                                                     }
                                                                 }
                                                             ],
@@ -696,7 +696,7 @@
                                                                     "function": "new_properties",
                                                                     "options": {
                                                                         "open": "\"false\"",
-                                                                        "facing": "\"east\""
+                                                                        "facing": "\"north\""
                                                                     }
                                                                 }
                                                             ],
@@ -704,7 +704,7 @@
                                                                 {
                                                                     "function": "new_properties",
                                                                     "options": {
-                                                                        "open": "\"false\"",
+                                                                        "open": "\"true\"",
                                                                         "facing": "\"east\""
                                                                     }
                                                                 }
@@ -713,8 +713,8 @@
                                                                 {
                                                                     "function": "new_properties",
                                                                     "options": {
-                                                                        "open": "\"false\"",
-                                                                        "facing": "\"east\""
+                                                                        "open": "\"true\"",
+                                                                        "facing": "\"south\""
                                                                     }
                                                                 }
                                                             ],
@@ -722,8 +722,8 @@
                                                                 {
                                                                     "function": "new_properties",
                                                                     "options": {
-                                                                        "open": "\"false\"",
-                                                                        "facing": "\"east\""
+                                                                        "open": "\"true\"",
+                                                                        "facing": "\"west\""
                                                                     }
                                                                 }
                                                             ],
@@ -731,8 +731,8 @@
                                                                 {
                                                                     "function": "new_properties",
                                                                     "options": {
-                                                                        "open": "\"false\"",
-                                                                        "facing": "\"east\""
+                                                                        "open": "\"true\"",
+                                                                        "facing": "\"north\""
                                                                     }
                                                                 }
                                                             ]
@@ -783,7 +783,7 @@
                                                                     "function": "new_properties",
                                                                     "options": {
                                                                         "open": "\"false\"",
-                                                                        "facing": "\"south\""
+                                                                        "facing": "\"east\""
                                                                     }
                                                                 }
                                                             ],
@@ -801,7 +801,7 @@
                                                                     "function": "new_properties",
                                                                     "options": {
                                                                         "open": "\"false\"",
-                                                                        "facing": "\"south\""
+                                                                        "facing": "\"west\""
                                                                     }
                                                                 }
                                                             ],
@@ -810,7 +810,7 @@
                                                                     "function": "new_properties",
                                                                     "options": {
                                                                         "open": "\"false\"",
-                                                                        "facing": "\"south\""
+                                                                        "facing": "\"north\""
                                                                     }
                                                                 }
                                                             ],
@@ -818,8 +818,8 @@
                                                                 {
                                                                     "function": "new_properties",
                                                                     "options": {
-                                                                        "open": "\"false\"",
-                                                                        "facing": "\"south\""
+                                                                        "open": "\"true\"",
+                                                                        "facing": "\"east\""
                                                                     }
                                                                 }
                                                             ],
@@ -827,7 +827,7 @@
                                                                 {
                                                                     "function": "new_properties",
                                                                     "options": {
-                                                                        "open": "\"false\"",
+                                                                        "open": "\"true\"",
                                                                         "facing": "\"south\""
                                                                     }
                                                                 }
@@ -836,8 +836,8 @@
                                                                 {
                                                                     "function": "new_properties",
                                                                     "options": {
-                                                                        "open": "\"false\"",
-                                                                        "facing": "\"south\""
+                                                                        "open": "\"true\"",
+                                                                        "facing": "\"west\""
                                                                     }
                                                                 }
                                                             ],
@@ -845,8 +845,8 @@
                                                                 {
                                                                     "function": "new_properties",
                                                                     "options": {
-                                                                        "open": "\"false\"",
-                                                                        "facing": "\"south\""
+                                                                        "open": "\"true\"",
+                                                                        "facing": "\"north\""
                                                                     }
                                                                 }
                                                             ]
@@ -897,7 +897,7 @@
                                                                     "function": "new_properties",
                                                                     "options": {
                                                                         "open": "\"false\"",
-                                                                        "facing": "\"west\""
+                                                                        "facing": "\"east\""
                                                                     }
                                                                 }
                                                             ],
@@ -906,7 +906,7 @@
                                                                     "function": "new_properties",
                                                                     "options": {
                                                                         "open": "\"false\"",
-                                                                        "facing": "\"west\""
+                                                                        "facing": "\"south\""
                                                                     }
                                                                 }
                                                             ],
@@ -924,7 +924,7 @@
                                                                     "function": "new_properties",
                                                                     "options": {
                                                                         "open": "\"false\"",
-                                                                        "facing": "\"west\""
+                                                                        "facing": "\"north\""
                                                                     }
                                                                 }
                                                             ],
@@ -932,8 +932,8 @@
                                                                 {
                                                                     "function": "new_properties",
                                                                     "options": {
-                                                                        "open": "\"false\"",
-                                                                        "facing": "\"west\""
+                                                                        "open": "\"true\"",
+                                                                        "facing": "\"east\""
                                                                     }
                                                                 }
                                                             ],
@@ -941,8 +941,8 @@
                                                                 {
                                                                     "function": "new_properties",
                                                                     "options": {
-                                                                        "open": "\"false\"",
-                                                                        "facing": "\"west\""
+                                                                        "open": "\"true\"",
+                                                                        "facing": "\"south\""
                                                                     }
                                                                 }
                                                             ],
@@ -950,7 +950,7 @@
                                                                 {
                                                                     "function": "new_properties",
                                                                     "options": {
-                                                                        "open": "\"false\"",
+                                                                        "open": "\"true\"",
                                                                         "facing": "\"west\""
                                                                     }
                                                                 }
@@ -959,8 +959,8 @@
                                                                 {
                                                                     "function": "new_properties",
                                                                     "options": {
-                                                                        "open": "\"false\"",
-                                                                        "facing": "\"west\""
+                                                                        "open": "\"true\"",
+                                                                        "facing": "\"north\""
                                                                     }
                                                                 }
                                                             ]
@@ -1011,7 +1011,7 @@
                                                                     "function": "new_properties",
                                                                     "options": {
                                                                         "open": "\"false\"",
-                                                                        "facing": "\"north\""
+                                                                        "facing": "\"east\""
                                                                     }
                                                                 }
                                                             ],
@@ -1020,7 +1020,7 @@
                                                                     "function": "new_properties",
                                                                     "options": {
                                                                         "open": "\"false\"",
-                                                                        "facing": "\"north\""
+                                                                        "facing": "\"south\""
                                                                     }
                                                                 }
                                                             ],
@@ -1029,7 +1029,7 @@
                                                                     "function": "new_properties",
                                                                     "options": {
                                                                         "open": "\"false\"",
-                                                                        "facing": "\"north\""
+                                                                        "facing": "\"west\""
                                                                     }
                                                                 }
                                                             ],
@@ -1046,8 +1046,8 @@
                                                                 {
                                                                     "function": "new_properties",
                                                                     "options": {
-                                                                        "open": "\"false\"",
-                                                                        "facing": "\"north\""
+                                                                        "open": "\"true\"",
+                                                                        "facing": "\"east\""
                                                                     }
                                                                 }
                                                             ],
@@ -1055,8 +1055,8 @@
                                                                 {
                                                                     "function": "new_properties",
                                                                     "options": {
-                                                                        "open": "\"false\"",
-                                                                        "facing": "\"north\""
+                                                                        "open": "\"true\"",
+                                                                        "facing": "\"south\""
                                                                     }
                                                                 }
                                                             ],
@@ -1064,8 +1064,8 @@
                                                                 {
                                                                     "function": "new_properties",
                                                                     "options": {
-                                                                        "open": "\"false\"",
-                                                                        "facing": "\"north\""
+                                                                        "open": "\"true\"",
+                                                                        "facing": "\"west\""
                                                                     }
                                                                 }
                                                             ],
@@ -1073,7 +1073,7 @@
                                                                 {
                                                                     "function": "new_properties",
                                                                     "options": {
-                                                                        "open": "\"false\"",
+                                                                        "open": "\"true\"",
                                                                         "facing": "\"north\""
                                                                     }
                                                                 }

--- a/PyMCTranslate/json/versions/java_1_12_2/block/numerical/to_universal/minecraft/vanilla/iron_door.json
+++ b/PyMCTranslate/json/versions/java_1_12_2/block/numerical/to_universal/minecraft/vanilla/iron_door.json
@@ -678,7 +678,7 @@
                                                                     "function": "new_properties",
                                                                     "options": {
                                                                         "open": "\"false\"",
-                                                                        "facing": "\"east\""
+                                                                        "facing": "\"south\""
                                                                     }
                                                                 }
                                                             ],
@@ -687,7 +687,7 @@
                                                                     "function": "new_properties",
                                                                     "options": {
                                                                         "open": "\"false\"",
-                                                                        "facing": "\"east\""
+                                                                        "facing": "\"west\""
                                                                     }
                                                                 }
                                                             ],
@@ -696,7 +696,7 @@
                                                                     "function": "new_properties",
                                                                     "options": {
                                                                         "open": "\"false\"",
-                                                                        "facing": "\"east\""
+                                                                        "facing": "\"north\""
                                                                     }
                                                                 }
                                                             ],
@@ -704,7 +704,7 @@
                                                                 {
                                                                     "function": "new_properties",
                                                                     "options": {
-                                                                        "open": "\"false\"",
+                                                                        "open": "\"true\"",
                                                                         "facing": "\"east\""
                                                                     }
                                                                 }
@@ -713,8 +713,8 @@
                                                                 {
                                                                     "function": "new_properties",
                                                                     "options": {
-                                                                        "open": "\"false\"",
-                                                                        "facing": "\"east\""
+                                                                        "open": "\"true\"",
+                                                                        "facing": "\"south\""
                                                                     }
                                                                 }
                                                             ],
@@ -722,8 +722,8 @@
                                                                 {
                                                                     "function": "new_properties",
                                                                     "options": {
-                                                                        "open": "\"false\"",
-                                                                        "facing": "\"east\""
+                                                                        "open": "\"true\"",
+                                                                        "facing": "\"west\""
                                                                     }
                                                                 }
                                                             ],
@@ -731,8 +731,8 @@
                                                                 {
                                                                     "function": "new_properties",
                                                                     "options": {
-                                                                        "open": "\"false\"",
-                                                                        "facing": "\"east\""
+                                                                        "open": "\"true\"",
+                                                                        "facing": "\"north\""
                                                                     }
                                                                 }
                                                             ]
@@ -783,7 +783,7 @@
                                                                     "function": "new_properties",
                                                                     "options": {
                                                                         "open": "\"false\"",
-                                                                        "facing": "\"south\""
+                                                                        "facing": "\"east\""
                                                                     }
                                                                 }
                                                             ],
@@ -801,7 +801,7 @@
                                                                     "function": "new_properties",
                                                                     "options": {
                                                                         "open": "\"false\"",
-                                                                        "facing": "\"south\""
+                                                                        "facing": "\"west\""
                                                                     }
                                                                 }
                                                             ],
@@ -810,7 +810,7 @@
                                                                     "function": "new_properties",
                                                                     "options": {
                                                                         "open": "\"false\"",
-                                                                        "facing": "\"south\""
+                                                                        "facing": "\"north\""
                                                                     }
                                                                 }
                                                             ],
@@ -818,8 +818,8 @@
                                                                 {
                                                                     "function": "new_properties",
                                                                     "options": {
-                                                                        "open": "\"false\"",
-                                                                        "facing": "\"south\""
+                                                                        "open": "\"true\"",
+                                                                        "facing": "\"east\""
                                                                     }
                                                                 }
                                                             ],
@@ -827,7 +827,7 @@
                                                                 {
                                                                     "function": "new_properties",
                                                                     "options": {
-                                                                        "open": "\"false\"",
+                                                                        "open": "\"true\"",
                                                                         "facing": "\"south\""
                                                                     }
                                                                 }
@@ -836,8 +836,8 @@
                                                                 {
                                                                     "function": "new_properties",
                                                                     "options": {
-                                                                        "open": "\"false\"",
-                                                                        "facing": "\"south\""
+                                                                        "open": "\"true\"",
+                                                                        "facing": "\"west\""
                                                                     }
                                                                 }
                                                             ],
@@ -845,8 +845,8 @@
                                                                 {
                                                                     "function": "new_properties",
                                                                     "options": {
-                                                                        "open": "\"false\"",
-                                                                        "facing": "\"south\""
+                                                                        "open": "\"true\"",
+                                                                        "facing": "\"north\""
                                                                     }
                                                                 }
                                                             ]
@@ -897,7 +897,7 @@
                                                                     "function": "new_properties",
                                                                     "options": {
                                                                         "open": "\"false\"",
-                                                                        "facing": "\"west\""
+                                                                        "facing": "\"east\""
                                                                     }
                                                                 }
                                                             ],
@@ -906,7 +906,7 @@
                                                                     "function": "new_properties",
                                                                     "options": {
                                                                         "open": "\"false\"",
-                                                                        "facing": "\"west\""
+                                                                        "facing": "\"south\""
                                                                     }
                                                                 }
                                                             ],
@@ -924,7 +924,7 @@
                                                                     "function": "new_properties",
                                                                     "options": {
                                                                         "open": "\"false\"",
-                                                                        "facing": "\"west\""
+                                                                        "facing": "\"north\""
                                                                     }
                                                                 }
                                                             ],
@@ -932,8 +932,8 @@
                                                                 {
                                                                     "function": "new_properties",
                                                                     "options": {
-                                                                        "open": "\"false\"",
-                                                                        "facing": "\"west\""
+                                                                        "open": "\"true\"",
+                                                                        "facing": "\"east\""
                                                                     }
                                                                 }
                                                             ],
@@ -941,8 +941,8 @@
                                                                 {
                                                                     "function": "new_properties",
                                                                     "options": {
-                                                                        "open": "\"false\"",
-                                                                        "facing": "\"west\""
+                                                                        "open": "\"true\"",
+                                                                        "facing": "\"south\""
                                                                     }
                                                                 }
                                                             ],
@@ -950,7 +950,7 @@
                                                                 {
                                                                     "function": "new_properties",
                                                                     "options": {
-                                                                        "open": "\"false\"",
+                                                                        "open": "\"true\"",
                                                                         "facing": "\"west\""
                                                                     }
                                                                 }
@@ -959,8 +959,8 @@
                                                                 {
                                                                     "function": "new_properties",
                                                                     "options": {
-                                                                        "open": "\"false\"",
-                                                                        "facing": "\"west\""
+                                                                        "open": "\"true\"",
+                                                                        "facing": "\"north\""
                                                                     }
                                                                 }
                                                             ]
@@ -1011,7 +1011,7 @@
                                                                     "function": "new_properties",
                                                                     "options": {
                                                                         "open": "\"false\"",
-                                                                        "facing": "\"north\""
+                                                                        "facing": "\"east\""
                                                                     }
                                                                 }
                                                             ],
@@ -1020,7 +1020,7 @@
                                                                     "function": "new_properties",
                                                                     "options": {
                                                                         "open": "\"false\"",
-                                                                        "facing": "\"north\""
+                                                                        "facing": "\"south\""
                                                                     }
                                                                 }
                                                             ],
@@ -1029,7 +1029,7 @@
                                                                     "function": "new_properties",
                                                                     "options": {
                                                                         "open": "\"false\"",
-                                                                        "facing": "\"north\""
+                                                                        "facing": "\"west\""
                                                                     }
                                                                 }
                                                             ],
@@ -1046,8 +1046,8 @@
                                                                 {
                                                                     "function": "new_properties",
                                                                     "options": {
-                                                                        "open": "\"false\"",
-                                                                        "facing": "\"north\""
+                                                                        "open": "\"true\"",
+                                                                        "facing": "\"east\""
                                                                     }
                                                                 }
                                                             ],
@@ -1055,8 +1055,8 @@
                                                                 {
                                                                     "function": "new_properties",
                                                                     "options": {
-                                                                        "open": "\"false\"",
-                                                                        "facing": "\"north\""
+                                                                        "open": "\"true\"",
+                                                                        "facing": "\"south\""
                                                                     }
                                                                 }
                                                             ],
@@ -1064,8 +1064,8 @@
                                                                 {
                                                                     "function": "new_properties",
                                                                     "options": {
-                                                                        "open": "\"false\"",
-                                                                        "facing": "\"north\""
+                                                                        "open": "\"true\"",
+                                                                        "facing": "\"west\""
                                                                     }
                                                                 }
                                                             ],
@@ -1073,7 +1073,7 @@
                                                                 {
                                                                     "function": "new_properties",
                                                                     "options": {
-                                                                        "open": "\"false\"",
+                                                                        "open": "\"true\"",
                                                                         "facing": "\"north\""
                                                                     }
                                                                 }

--- a/PyMCTranslate/json/versions/java_1_12_2/block/numerical/to_universal/minecraft/vanilla/jungle_door.json
+++ b/PyMCTranslate/json/versions/java_1_12_2/block/numerical/to_universal/minecraft/vanilla/jungle_door.json
@@ -678,7 +678,7 @@
                                                                     "function": "new_properties",
                                                                     "options": {
                                                                         "open": "\"false\"",
-                                                                        "facing": "\"east\""
+                                                                        "facing": "\"south\""
                                                                     }
                                                                 }
                                                             ],
@@ -687,7 +687,7 @@
                                                                     "function": "new_properties",
                                                                     "options": {
                                                                         "open": "\"false\"",
-                                                                        "facing": "\"east\""
+                                                                        "facing": "\"west\""
                                                                     }
                                                                 }
                                                             ],
@@ -696,7 +696,7 @@
                                                                     "function": "new_properties",
                                                                     "options": {
                                                                         "open": "\"false\"",
-                                                                        "facing": "\"east\""
+                                                                        "facing": "\"north\""
                                                                     }
                                                                 }
                                                             ],
@@ -704,7 +704,7 @@
                                                                 {
                                                                     "function": "new_properties",
                                                                     "options": {
-                                                                        "open": "\"false\"",
+                                                                        "open": "\"true\"",
                                                                         "facing": "\"east\""
                                                                     }
                                                                 }
@@ -713,8 +713,8 @@
                                                                 {
                                                                     "function": "new_properties",
                                                                     "options": {
-                                                                        "open": "\"false\"",
-                                                                        "facing": "\"east\""
+                                                                        "open": "\"true\"",
+                                                                        "facing": "\"south\""
                                                                     }
                                                                 }
                                                             ],
@@ -722,8 +722,8 @@
                                                                 {
                                                                     "function": "new_properties",
                                                                     "options": {
-                                                                        "open": "\"false\"",
-                                                                        "facing": "\"east\""
+                                                                        "open": "\"true\"",
+                                                                        "facing": "\"west\""
                                                                     }
                                                                 }
                                                             ],
@@ -731,8 +731,8 @@
                                                                 {
                                                                     "function": "new_properties",
                                                                     "options": {
-                                                                        "open": "\"false\"",
-                                                                        "facing": "\"east\""
+                                                                        "open": "\"true\"",
+                                                                        "facing": "\"north\""
                                                                     }
                                                                 }
                                                             ]
@@ -783,7 +783,7 @@
                                                                     "function": "new_properties",
                                                                     "options": {
                                                                         "open": "\"false\"",
-                                                                        "facing": "\"south\""
+                                                                        "facing": "\"east\""
                                                                     }
                                                                 }
                                                             ],
@@ -801,7 +801,7 @@
                                                                     "function": "new_properties",
                                                                     "options": {
                                                                         "open": "\"false\"",
-                                                                        "facing": "\"south\""
+                                                                        "facing": "\"west\""
                                                                     }
                                                                 }
                                                             ],
@@ -810,7 +810,7 @@
                                                                     "function": "new_properties",
                                                                     "options": {
                                                                         "open": "\"false\"",
-                                                                        "facing": "\"south\""
+                                                                        "facing": "\"north\""
                                                                     }
                                                                 }
                                                             ],
@@ -818,8 +818,8 @@
                                                                 {
                                                                     "function": "new_properties",
                                                                     "options": {
-                                                                        "open": "\"false\"",
-                                                                        "facing": "\"south\""
+                                                                        "open": "\"true\"",
+                                                                        "facing": "\"east\""
                                                                     }
                                                                 }
                                                             ],
@@ -827,7 +827,7 @@
                                                                 {
                                                                     "function": "new_properties",
                                                                     "options": {
-                                                                        "open": "\"false\"",
+                                                                        "open": "\"true\"",
                                                                         "facing": "\"south\""
                                                                     }
                                                                 }
@@ -836,8 +836,8 @@
                                                                 {
                                                                     "function": "new_properties",
                                                                     "options": {
-                                                                        "open": "\"false\"",
-                                                                        "facing": "\"south\""
+                                                                        "open": "\"true\"",
+                                                                        "facing": "\"west\""
                                                                     }
                                                                 }
                                                             ],
@@ -845,8 +845,8 @@
                                                                 {
                                                                     "function": "new_properties",
                                                                     "options": {
-                                                                        "open": "\"false\"",
-                                                                        "facing": "\"south\""
+                                                                        "open": "\"true\"",
+                                                                        "facing": "\"north\""
                                                                     }
                                                                 }
                                                             ]
@@ -897,7 +897,7 @@
                                                                     "function": "new_properties",
                                                                     "options": {
                                                                         "open": "\"false\"",
-                                                                        "facing": "\"west\""
+                                                                        "facing": "\"east\""
                                                                     }
                                                                 }
                                                             ],
@@ -906,7 +906,7 @@
                                                                     "function": "new_properties",
                                                                     "options": {
                                                                         "open": "\"false\"",
-                                                                        "facing": "\"west\""
+                                                                        "facing": "\"south\""
                                                                     }
                                                                 }
                                                             ],
@@ -924,7 +924,7 @@
                                                                     "function": "new_properties",
                                                                     "options": {
                                                                         "open": "\"false\"",
-                                                                        "facing": "\"west\""
+                                                                        "facing": "\"north\""
                                                                     }
                                                                 }
                                                             ],
@@ -932,8 +932,8 @@
                                                                 {
                                                                     "function": "new_properties",
                                                                     "options": {
-                                                                        "open": "\"false\"",
-                                                                        "facing": "\"west\""
+                                                                        "open": "\"true\"",
+                                                                        "facing": "\"east\""
                                                                     }
                                                                 }
                                                             ],
@@ -941,8 +941,8 @@
                                                                 {
                                                                     "function": "new_properties",
                                                                     "options": {
-                                                                        "open": "\"false\"",
-                                                                        "facing": "\"west\""
+                                                                        "open": "\"true\"",
+                                                                        "facing": "\"south\""
                                                                     }
                                                                 }
                                                             ],
@@ -950,7 +950,7 @@
                                                                 {
                                                                     "function": "new_properties",
                                                                     "options": {
-                                                                        "open": "\"false\"",
+                                                                        "open": "\"true\"",
                                                                         "facing": "\"west\""
                                                                     }
                                                                 }
@@ -959,8 +959,8 @@
                                                                 {
                                                                     "function": "new_properties",
                                                                     "options": {
-                                                                        "open": "\"false\"",
-                                                                        "facing": "\"west\""
+                                                                        "open": "\"true\"",
+                                                                        "facing": "\"north\""
                                                                     }
                                                                 }
                                                             ]
@@ -1011,7 +1011,7 @@
                                                                     "function": "new_properties",
                                                                     "options": {
                                                                         "open": "\"false\"",
-                                                                        "facing": "\"north\""
+                                                                        "facing": "\"east\""
                                                                     }
                                                                 }
                                                             ],
@@ -1020,7 +1020,7 @@
                                                                     "function": "new_properties",
                                                                     "options": {
                                                                         "open": "\"false\"",
-                                                                        "facing": "\"north\""
+                                                                        "facing": "\"south\""
                                                                     }
                                                                 }
                                                             ],
@@ -1029,7 +1029,7 @@
                                                                     "function": "new_properties",
                                                                     "options": {
                                                                         "open": "\"false\"",
-                                                                        "facing": "\"north\""
+                                                                        "facing": "\"west\""
                                                                     }
                                                                 }
                                                             ],
@@ -1046,8 +1046,8 @@
                                                                 {
                                                                     "function": "new_properties",
                                                                     "options": {
-                                                                        "open": "\"false\"",
-                                                                        "facing": "\"north\""
+                                                                        "open": "\"true\"",
+                                                                        "facing": "\"east\""
                                                                     }
                                                                 }
                                                             ],
@@ -1055,8 +1055,8 @@
                                                                 {
                                                                     "function": "new_properties",
                                                                     "options": {
-                                                                        "open": "\"false\"",
-                                                                        "facing": "\"north\""
+                                                                        "open": "\"true\"",
+                                                                        "facing": "\"south\""
                                                                     }
                                                                 }
                                                             ],
@@ -1064,8 +1064,8 @@
                                                                 {
                                                                     "function": "new_properties",
                                                                     "options": {
-                                                                        "open": "\"false\"",
-                                                                        "facing": "\"north\""
+                                                                        "open": "\"true\"",
+                                                                        "facing": "\"west\""
                                                                     }
                                                                 }
                                                             ],
@@ -1073,7 +1073,7 @@
                                                                 {
                                                                     "function": "new_properties",
                                                                     "options": {
-                                                                        "open": "\"false\"",
+                                                                        "open": "\"true\"",
                                                                         "facing": "\"north\""
                                                                     }
                                                                 }

--- a/PyMCTranslate/json/versions/java_1_12_2/block/numerical/to_universal/minecraft/vanilla/spruce_door.json
+++ b/PyMCTranslate/json/versions/java_1_12_2/block/numerical/to_universal/minecraft/vanilla/spruce_door.json
@@ -678,7 +678,7 @@
                                                                     "function": "new_properties",
                                                                     "options": {
                                                                         "open": "\"false\"",
-                                                                        "facing": "\"east\""
+                                                                        "facing": "\"south\""
                                                                     }
                                                                 }
                                                             ],
@@ -687,7 +687,7 @@
                                                                     "function": "new_properties",
                                                                     "options": {
                                                                         "open": "\"false\"",
-                                                                        "facing": "\"east\""
+                                                                        "facing": "\"west\""
                                                                     }
                                                                 }
                                                             ],
@@ -696,7 +696,7 @@
                                                                     "function": "new_properties",
                                                                     "options": {
                                                                         "open": "\"false\"",
-                                                                        "facing": "\"east\""
+                                                                        "facing": "\"north\""
                                                                     }
                                                                 }
                                                             ],
@@ -704,7 +704,7 @@
                                                                 {
                                                                     "function": "new_properties",
                                                                     "options": {
-                                                                        "open": "\"false\"",
+                                                                        "open": "\"true\"",
                                                                         "facing": "\"east\""
                                                                     }
                                                                 }
@@ -713,8 +713,8 @@
                                                                 {
                                                                     "function": "new_properties",
                                                                     "options": {
-                                                                        "open": "\"false\"",
-                                                                        "facing": "\"east\""
+                                                                        "open": "\"true\"",
+                                                                        "facing": "\"south\""
                                                                     }
                                                                 }
                                                             ],
@@ -722,8 +722,8 @@
                                                                 {
                                                                     "function": "new_properties",
                                                                     "options": {
-                                                                        "open": "\"false\"",
-                                                                        "facing": "\"east\""
+                                                                        "open": "\"true\"",
+                                                                        "facing": "\"west\""
                                                                     }
                                                                 }
                                                             ],
@@ -731,8 +731,8 @@
                                                                 {
                                                                     "function": "new_properties",
                                                                     "options": {
-                                                                        "open": "\"false\"",
-                                                                        "facing": "\"east\""
+                                                                        "open": "\"true\"",
+                                                                        "facing": "\"north\""
                                                                     }
                                                                 }
                                                             ]
@@ -783,7 +783,7 @@
                                                                     "function": "new_properties",
                                                                     "options": {
                                                                         "open": "\"false\"",
-                                                                        "facing": "\"south\""
+                                                                        "facing": "\"east\""
                                                                     }
                                                                 }
                                                             ],
@@ -801,7 +801,7 @@
                                                                     "function": "new_properties",
                                                                     "options": {
                                                                         "open": "\"false\"",
-                                                                        "facing": "\"south\""
+                                                                        "facing": "\"west\""
                                                                     }
                                                                 }
                                                             ],
@@ -810,7 +810,7 @@
                                                                     "function": "new_properties",
                                                                     "options": {
                                                                         "open": "\"false\"",
-                                                                        "facing": "\"south\""
+                                                                        "facing": "\"north\""
                                                                     }
                                                                 }
                                                             ],
@@ -818,8 +818,8 @@
                                                                 {
                                                                     "function": "new_properties",
                                                                     "options": {
-                                                                        "open": "\"false\"",
-                                                                        "facing": "\"south\""
+                                                                        "open": "\"true\"",
+                                                                        "facing": "\"east\""
                                                                     }
                                                                 }
                                                             ],
@@ -827,7 +827,7 @@
                                                                 {
                                                                     "function": "new_properties",
                                                                     "options": {
-                                                                        "open": "\"false\"",
+                                                                        "open": "\"true\"",
                                                                         "facing": "\"south\""
                                                                     }
                                                                 }
@@ -836,8 +836,8 @@
                                                                 {
                                                                     "function": "new_properties",
                                                                     "options": {
-                                                                        "open": "\"false\"",
-                                                                        "facing": "\"south\""
+                                                                        "open": "\"true\"",
+                                                                        "facing": "\"west\""
                                                                     }
                                                                 }
                                                             ],
@@ -845,8 +845,8 @@
                                                                 {
                                                                     "function": "new_properties",
                                                                     "options": {
-                                                                        "open": "\"false\"",
-                                                                        "facing": "\"south\""
+                                                                        "open": "\"true\"",
+                                                                        "facing": "\"north\""
                                                                     }
                                                                 }
                                                             ]
@@ -897,7 +897,7 @@
                                                                     "function": "new_properties",
                                                                     "options": {
                                                                         "open": "\"false\"",
-                                                                        "facing": "\"west\""
+                                                                        "facing": "\"east\""
                                                                     }
                                                                 }
                                                             ],
@@ -906,7 +906,7 @@
                                                                     "function": "new_properties",
                                                                     "options": {
                                                                         "open": "\"false\"",
-                                                                        "facing": "\"west\""
+                                                                        "facing": "\"south\""
                                                                     }
                                                                 }
                                                             ],
@@ -924,7 +924,7 @@
                                                                     "function": "new_properties",
                                                                     "options": {
                                                                         "open": "\"false\"",
-                                                                        "facing": "\"west\""
+                                                                        "facing": "\"north\""
                                                                     }
                                                                 }
                                                             ],
@@ -932,8 +932,8 @@
                                                                 {
                                                                     "function": "new_properties",
                                                                     "options": {
-                                                                        "open": "\"false\"",
-                                                                        "facing": "\"west\""
+                                                                        "open": "\"true\"",
+                                                                        "facing": "\"east\""
                                                                     }
                                                                 }
                                                             ],
@@ -941,8 +941,8 @@
                                                                 {
                                                                     "function": "new_properties",
                                                                     "options": {
-                                                                        "open": "\"false\"",
-                                                                        "facing": "\"west\""
+                                                                        "open": "\"true\"",
+                                                                        "facing": "\"south\""
                                                                     }
                                                                 }
                                                             ],
@@ -950,7 +950,7 @@
                                                                 {
                                                                     "function": "new_properties",
                                                                     "options": {
-                                                                        "open": "\"false\"",
+                                                                        "open": "\"true\"",
                                                                         "facing": "\"west\""
                                                                     }
                                                                 }
@@ -959,8 +959,8 @@
                                                                 {
                                                                     "function": "new_properties",
                                                                     "options": {
-                                                                        "open": "\"false\"",
-                                                                        "facing": "\"west\""
+                                                                        "open": "\"true\"",
+                                                                        "facing": "\"north\""
                                                                     }
                                                                 }
                                                             ]
@@ -1011,7 +1011,7 @@
                                                                     "function": "new_properties",
                                                                     "options": {
                                                                         "open": "\"false\"",
-                                                                        "facing": "\"north\""
+                                                                        "facing": "\"east\""
                                                                     }
                                                                 }
                                                             ],
@@ -1020,7 +1020,7 @@
                                                                     "function": "new_properties",
                                                                     "options": {
                                                                         "open": "\"false\"",
-                                                                        "facing": "\"north\""
+                                                                        "facing": "\"south\""
                                                                     }
                                                                 }
                                                             ],
@@ -1029,7 +1029,7 @@
                                                                     "function": "new_properties",
                                                                     "options": {
                                                                         "open": "\"false\"",
-                                                                        "facing": "\"north\""
+                                                                        "facing": "\"west\""
                                                                     }
                                                                 }
                                                             ],
@@ -1046,8 +1046,8 @@
                                                                 {
                                                                     "function": "new_properties",
                                                                     "options": {
-                                                                        "open": "\"false\"",
-                                                                        "facing": "\"north\""
+                                                                        "open": "\"true\"",
+                                                                        "facing": "\"east\""
                                                                     }
                                                                 }
                                                             ],
@@ -1055,8 +1055,8 @@
                                                                 {
                                                                     "function": "new_properties",
                                                                     "options": {
-                                                                        "open": "\"false\"",
-                                                                        "facing": "\"north\""
+                                                                        "open": "\"true\"",
+                                                                        "facing": "\"south\""
                                                                     }
                                                                 }
                                                             ],
@@ -1064,8 +1064,8 @@
                                                                 {
                                                                     "function": "new_properties",
                                                                     "options": {
-                                                                        "open": "\"false\"",
-                                                                        "facing": "\"north\""
+                                                                        "open": "\"true\"",
+                                                                        "facing": "\"west\""
                                                                     }
                                                                 }
                                                             ],
@@ -1073,7 +1073,7 @@
                                                                 {
                                                                     "function": "new_properties",
                                                                     "options": {
-                                                                        "open": "\"false\"",
+                                                                        "open": "\"true\"",
                                                                         "facing": "\"north\""
                                                                     }
                                                                 }

--- a/PyMCTranslate/json/versions/java_1_12_2/block/numerical/to_universal/minecraft/vanilla/wooden_door.json
+++ b/PyMCTranslate/json/versions/java_1_12_2/block/numerical/to_universal/minecraft/vanilla/wooden_door.json
@@ -678,7 +678,7 @@
                                                                     "function": "new_properties",
                                                                     "options": {
                                                                         "open": "\"false\"",
-                                                                        "facing": "\"east\""
+                                                                        "facing": "\"south\""
                                                                     }
                                                                 }
                                                             ],
@@ -687,7 +687,7 @@
                                                                     "function": "new_properties",
                                                                     "options": {
                                                                         "open": "\"false\"",
-                                                                        "facing": "\"east\""
+                                                                        "facing": "\"west\""
                                                                     }
                                                                 }
                                                             ],
@@ -696,7 +696,7 @@
                                                                     "function": "new_properties",
                                                                     "options": {
                                                                         "open": "\"false\"",
-                                                                        "facing": "\"east\""
+                                                                        "facing": "\"north\""
                                                                     }
                                                                 }
                                                             ],
@@ -704,7 +704,7 @@
                                                                 {
                                                                     "function": "new_properties",
                                                                     "options": {
-                                                                        "open": "\"false\"",
+                                                                        "open": "\"true\"",
                                                                         "facing": "\"east\""
                                                                     }
                                                                 }
@@ -713,8 +713,8 @@
                                                                 {
                                                                     "function": "new_properties",
                                                                     "options": {
-                                                                        "open": "\"false\"",
-                                                                        "facing": "\"east\""
+                                                                        "open": "\"true\"",
+                                                                        "facing": "\"south\""
                                                                     }
                                                                 }
                                                             ],
@@ -722,8 +722,8 @@
                                                                 {
                                                                     "function": "new_properties",
                                                                     "options": {
-                                                                        "open": "\"false\"",
-                                                                        "facing": "\"east\""
+                                                                        "open": "\"true\"",
+                                                                        "facing": "\"west\""
                                                                     }
                                                                 }
                                                             ],
@@ -731,8 +731,8 @@
                                                                 {
                                                                     "function": "new_properties",
                                                                     "options": {
-                                                                        "open": "\"false\"",
-                                                                        "facing": "\"east\""
+                                                                        "open": "\"true\"",
+                                                                        "facing": "\"north\""
                                                                     }
                                                                 }
                                                             ]
@@ -783,7 +783,7 @@
                                                                     "function": "new_properties",
                                                                     "options": {
                                                                         "open": "\"false\"",
-                                                                        "facing": "\"south\""
+                                                                        "facing": "\"east\""
                                                                     }
                                                                 }
                                                             ],
@@ -801,7 +801,7 @@
                                                                     "function": "new_properties",
                                                                     "options": {
                                                                         "open": "\"false\"",
-                                                                        "facing": "\"south\""
+                                                                        "facing": "\"west\""
                                                                     }
                                                                 }
                                                             ],
@@ -810,7 +810,7 @@
                                                                     "function": "new_properties",
                                                                     "options": {
                                                                         "open": "\"false\"",
-                                                                        "facing": "\"south\""
+                                                                        "facing": "\"north\""
                                                                     }
                                                                 }
                                                             ],
@@ -818,8 +818,8 @@
                                                                 {
                                                                     "function": "new_properties",
                                                                     "options": {
-                                                                        "open": "\"false\"",
-                                                                        "facing": "\"south\""
+                                                                        "open": "\"true\"",
+                                                                        "facing": "\"east\""
                                                                     }
                                                                 }
                                                             ],
@@ -827,7 +827,7 @@
                                                                 {
                                                                     "function": "new_properties",
                                                                     "options": {
-                                                                        "open": "\"false\"",
+                                                                        "open": "\"true\"",
                                                                         "facing": "\"south\""
                                                                     }
                                                                 }
@@ -836,8 +836,8 @@
                                                                 {
                                                                     "function": "new_properties",
                                                                     "options": {
-                                                                        "open": "\"false\"",
-                                                                        "facing": "\"south\""
+                                                                        "open": "\"true\"",
+                                                                        "facing": "\"west\""
                                                                     }
                                                                 }
                                                             ],
@@ -845,8 +845,8 @@
                                                                 {
                                                                     "function": "new_properties",
                                                                     "options": {
-                                                                        "open": "\"false\"",
-                                                                        "facing": "\"south\""
+                                                                        "open": "\"true\"",
+                                                                        "facing": "\"north\""
                                                                     }
                                                                 }
                                                             ]
@@ -897,7 +897,7 @@
                                                                     "function": "new_properties",
                                                                     "options": {
                                                                         "open": "\"false\"",
-                                                                        "facing": "\"west\""
+                                                                        "facing": "\"east\""
                                                                     }
                                                                 }
                                                             ],
@@ -906,7 +906,7 @@
                                                                     "function": "new_properties",
                                                                     "options": {
                                                                         "open": "\"false\"",
-                                                                        "facing": "\"west\""
+                                                                        "facing": "\"south\""
                                                                     }
                                                                 }
                                                             ],
@@ -924,7 +924,7 @@
                                                                     "function": "new_properties",
                                                                     "options": {
                                                                         "open": "\"false\"",
-                                                                        "facing": "\"west\""
+                                                                        "facing": "\"north\""
                                                                     }
                                                                 }
                                                             ],
@@ -932,8 +932,8 @@
                                                                 {
                                                                     "function": "new_properties",
                                                                     "options": {
-                                                                        "open": "\"false\"",
-                                                                        "facing": "\"west\""
+                                                                        "open": "\"true\"",
+                                                                        "facing": "\"east\""
                                                                     }
                                                                 }
                                                             ],
@@ -941,8 +941,8 @@
                                                                 {
                                                                     "function": "new_properties",
                                                                     "options": {
-                                                                        "open": "\"false\"",
-                                                                        "facing": "\"west\""
+                                                                        "open": "\"true\"",
+                                                                        "facing": "\"south\""
                                                                     }
                                                                 }
                                                             ],
@@ -950,7 +950,7 @@
                                                                 {
                                                                     "function": "new_properties",
                                                                     "options": {
-                                                                        "open": "\"false\"",
+                                                                        "open": "\"true\"",
                                                                         "facing": "\"west\""
                                                                     }
                                                                 }
@@ -959,8 +959,8 @@
                                                                 {
                                                                     "function": "new_properties",
                                                                     "options": {
-                                                                        "open": "\"false\"",
-                                                                        "facing": "\"west\""
+                                                                        "open": "\"true\"",
+                                                                        "facing": "\"north\""
                                                                     }
                                                                 }
                                                             ]
@@ -1011,7 +1011,7 @@
                                                                     "function": "new_properties",
                                                                     "options": {
                                                                         "open": "\"false\"",
-                                                                        "facing": "\"north\""
+                                                                        "facing": "\"east\""
                                                                     }
                                                                 }
                                                             ],
@@ -1020,7 +1020,7 @@
                                                                     "function": "new_properties",
                                                                     "options": {
                                                                         "open": "\"false\"",
-                                                                        "facing": "\"north\""
+                                                                        "facing": "\"south\""
                                                                     }
                                                                 }
                                                             ],
@@ -1029,7 +1029,7 @@
                                                                     "function": "new_properties",
                                                                     "options": {
                                                                         "open": "\"false\"",
-                                                                        "facing": "\"north\""
+                                                                        "facing": "\"west\""
                                                                     }
                                                                 }
                                                             ],
@@ -1046,8 +1046,8 @@
                                                                 {
                                                                     "function": "new_properties",
                                                                     "options": {
-                                                                        "open": "\"false\"",
-                                                                        "facing": "\"north\""
+                                                                        "open": "\"true\"",
+                                                                        "facing": "\"east\""
                                                                     }
                                                                 }
                                                             ],
@@ -1055,8 +1055,8 @@
                                                                 {
                                                                     "function": "new_properties",
                                                                     "options": {
-                                                                        "open": "\"false\"",
-                                                                        "facing": "\"north\""
+                                                                        "open": "\"true\"",
+                                                                        "facing": "\"south\""
                                                                     }
                                                                 }
                                                             ],
@@ -1064,8 +1064,8 @@
                                                                 {
                                                                     "function": "new_properties",
                                                                     "options": {
-                                                                        "open": "\"false\"",
-                                                                        "facing": "\"north\""
+                                                                        "open": "\"true\"",
+                                                                        "facing": "\"west\""
                                                                     }
                                                                 }
                                                             ],
@@ -1073,7 +1073,7 @@
                                                                 {
                                                                     "function": "new_properties",
                                                                     "options": {
-                                                                        "open": "\"false\"",
+                                                                        "open": "\"true\"",
                                                                         "facing": "\"north\""
                                                                     }
                                                                 }


### PR DESCRIPTION
The orientation and open state for upper doors were not being properly read from the lower half. It was checking the lower half but setting it to the same value no matter what. This fixes it with the proper mapping.

Bottom=0 => open="false", facing="east"
Bottom=1 => open="false", facing="south"
Bottom=2 => open="false", facing="west"
Bottom=3 => open="false", facing="north"
Bottom=4 => open="true", facing="east"
Bottom=5 => open="true", facing="south"
Bottom=6 => open="true", facing="west"
Bottom=7 => open="true", facing="north"

As already mapped for the lower halves earlier in the file.

I believe this is the only Java version this applies to since it changed in 1.13. This fix may also be needed for some bedrock versions, but I'm not sure.